### PR TITLE
feat: improve site seo and discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build

--- a/app/content/blog.test.ts
+++ b/app/content/blog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBlogPostSummary,
+  formatDisplayDate,
+  getBlogPostSummaries,
+} from "./blog";
+
+describe("blog content helpers", () => {
+  it("creates a summary from normalized frontmatter", () => {
+    const post = createBlogPostSummary("./blog.example.mdx", {
+      created: "2025-07-28",
+      meta: [
+        { title: "Example Post" },
+        { name: "description", content: "A useful example." },
+        { name: "og:image", content: "https://example.com/image.jpg" },
+      ],
+    });
+
+    expect(post).toMatchObject({
+      slug: "example",
+      created: "2025-07-28",
+      displayDate: "July 28, 2025",
+      title: "Example Post",
+      description: "A useful example.",
+      img: "https://example.com/image.jpg",
+    });
+  });
+
+  it("sorts posts newest first by ISO date", () => {
+    const posts = getBlogPostSummaries({
+      "./blog.old.mdx": {
+        frontmatter: { created: "2024-01-01", meta: [{ title: "Old" }] },
+      },
+      "./blog.new.mdx": {
+        frontmatter: { created: "2025-07-28", meta: [{ title: "New" }] },
+      },
+    });
+
+    expect(posts.map((post) => post.slug)).toEqual(["new", "old"]);
+  });
+
+  it("formats ISO dates for display", () => {
+    expect(formatDisplayDate("2024-01-01")).toBe("January 1, 2024");
+  });
+});

--- a/app/content/blog.ts
+++ b/app/content/blog.ts
@@ -1,0 +1,68 @@
+export type MdxFrontmatterMeta = {
+  title?: string;
+  name?: string;
+  content?: string;
+};
+
+export type BlogFrontmatter = {
+  created?: string;
+  meta: MdxFrontmatterMeta[];
+};
+
+export type BlogMdxModule = {
+  frontmatter: BlogFrontmatter;
+};
+
+export type BlogPostSummary = {
+  slug: string;
+  created?: string;
+  displayDate?: string;
+  title?: string;
+  description?: string;
+  img?: string;
+};
+
+function getMetaTitle(meta: MdxFrontmatterMeta[]) {
+  return meta.find((item) => item.title)?.title;
+}
+
+function getMetaContent(meta: MdxFrontmatterMeta[], name: string) {
+  return meta.find((item) => item.name === name)?.content;
+}
+
+export function formatDisplayDate(isoDate: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${isoDate}T00:00:00.000Z`));
+}
+
+export function createBlogPostSummary(
+  fileName: string,
+  frontmatter: BlogFrontmatter,
+): BlogPostSummary {
+  const slug = fileName.replace(/\.mdx?$/, "").replace(/\.\/blog\./, "");
+
+  return {
+    slug,
+    created: frontmatter.created,
+    displayDate: frontmatter.created
+      ? formatDisplayDate(frontmatter.created)
+      : undefined,
+    title: getMetaTitle(frontmatter.meta),
+    description: getMetaContent(frontmatter.meta, "description"),
+    img: getMetaContent(frontmatter.meta, "og:image"),
+  };
+}
+
+export function getBlogPostSummaries(
+  posts: Record<string, unknown>,
+): BlogPostSummary[] {
+  return Object.entries(posts)
+    .map(([fileName, mod]) =>
+      createBlogPostSummary(fileName, (mod as BlogMdxModule).frontmatter),
+    )
+    .sort((a, b) => (b.created ?? "").localeCompare(a.created ?? ""));
+}

--- a/app/lib/feeds.test.ts
+++ b/app/lib/feeds.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRobotsTxt,
+  buildRssFeed,
+  buildSitemapXml,
+  type SitemapEntry,
+} from "./feeds";
+
+const posts = [
+  {
+    slug: "oil-code",
+    created: "2025-07-28",
+    displayDate: "July 28, 2025",
+    title: "The what, why, and how of Oil.code",
+    description: "The what, why, and how of my journey creating oil.code.",
+    img: "https://example.com/oil.jpg",
+  },
+];
+
+describe("feed helpers", () => {
+  it("builds a sitemap that includes public pages and blog posts", () => {
+    const entries: SitemapEntry[] = [
+      { path: "/", priority: "1.0" },
+      { path: "/blog", priority: "0.8" },
+      { path: "/blog/oil-code", lastmod: "2025-07-28", priority: "0.7" },
+    ];
+
+    const xml = buildSitemapXml("https://corwinmarsh.com", entries);
+
+    expect(xml).toContain("<loc>https://corwinmarsh.com/</loc>");
+    expect(xml).toContain("<loc>https://corwinmarsh.com/blog/oil-code</loc>");
+    expect(xml).toContain("<lastmod>2025-07-28</lastmod>");
+    expect(xml).not.toContain("wishlist");
+  });
+
+  it("builds an RSS feed from blog summaries", () => {
+    const xml = buildRssFeed("https://corwinmarsh.com", posts);
+
+    expect(xml).toContain("<channel>");
+    expect(xml).toContain("<title>Corwin W. Marsh - Writing</title>");
+    expect(xml).toContain("<link>https://corwinmarsh.com/blog/oil-code</link>");
+    expect(xml).toContain(
+      "The what, why, and how of my journey creating oil.code.",
+    );
+  });
+
+  it("points robots.txt to the sitemap", () => {
+    expect(buildRobotsTxt("https://corwinmarsh.com")).toBe(
+      "User-agent: *\nAllow: /\nSitemap: https://corwinmarsh.com/sitemap.xml\n",
+    );
+  });
+});

--- a/app/lib/feeds.ts
+++ b/app/lib/feeds.ts
@@ -1,0 +1,72 @@
+import { type BlogPostSummary } from "~/content/blog";
+import { createCanonicalUrl, defaultSiteDescription, siteName } from "./seo";
+
+export interface SitemapEntry {
+  path: string;
+  lastmod?: string;
+  changefreq?: "daily" | "weekly" | "monthly" | "yearly";
+  priority?: string;
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function buildSitemapXml(origin: string, entries: SitemapEntry[]) {
+  const urls = entries
+    .map((entry) => {
+      const lines = [
+        "  <url>",
+        `    <loc>${escapeXml(createCanonicalUrl(origin, entry.path))}</loc>`,
+      ];
+
+      if (entry.lastmod) lines.push(`    <lastmod>${entry.lastmod}</lastmod>`);
+      if (entry.changefreq) {
+        lines.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+      }
+      if (entry.priority)
+        lines.push(`    <priority>${entry.priority}</priority>`);
+
+      lines.push("  </url>");
+      return lines.join("\n");
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+export function buildRssFeed(origin: string, posts: BlogPostSummary[]) {
+  const items = posts
+    .map((post) => {
+      const postUrl = createCanonicalUrl(origin, `/blog/${post.slug}`);
+      const pubDate = post.created
+        ? new Date(`${post.created}T00:00:00.000Z`).toUTCString()
+        : undefined;
+
+      return [
+        "    <item>",
+        `      <title>${escapeXml(post.title ?? post.slug)}</title>`,
+        `      <link>${escapeXml(postUrl)}</link>`,
+        `      <guid>${escapeXml(postUrl)}</guid>`,
+        post.description
+          ? `      <description>${escapeXml(post.description)}</description>`
+          : undefined,
+        pubDate ? `      <pubDate>${pubDate}</pubDate>` : undefined,
+        "    </item>",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n  <channel>\n    <title>${escapeXml(siteName)} - Writing</title>\n    <link>${escapeXml(createCanonicalUrl(origin, "/blog"))}</link>\n    <description>${escapeXml(defaultSiteDescription)}</description>\n${items}\n  </channel>\n</rss>\n`;
+}
+
+export function buildRobotsTxt(origin: string) {
+  return `User-agent: *\nAllow: /\nSitemap: ${createCanonicalUrl(origin, "/sitemap.xml")}\n`;
+}

--- a/app/lib/seo.test.ts
+++ b/app/lib/seo.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMeta,
+  createCanonicalUrl,
+  defaultSiteDescription,
+  getOriginFromMatches,
+} from "./seo";
+
+describe("seo helpers", () => {
+  it("builds a complete default meta set with canonical and social tags", () => {
+    const meta = buildMeta({
+      origin: "https://corwinmarsh.com",
+      pathname: "/blog",
+      title: "Writing - Corwin W. Marsh",
+      description: "Notes on software engineering and developer tooling.",
+      image: "/profile-2025.jpg",
+      type: "website",
+    });
+
+    expect(meta).toContainEqual({ title: "Writing - Corwin W. Marsh" });
+    expect(meta).toContainEqual({
+      name: "description",
+      content: "Notes on software engineering and developer tooling.",
+    });
+    expect(meta).toContainEqual({
+      property: "og:url",
+      content: "https://corwinmarsh.com/blog",
+    });
+    expect(meta).toContainEqual({
+      property: "og:image",
+      content: "https://corwinmarsh.com/profile-2025.jpg",
+    });
+    expect(meta).toContainEqual({
+      name: "twitter:site",
+      content: "@CorwinMarsh",
+    });
+    expect(meta).toContainEqual({
+      name: "twitter:card",
+      content: "summary_large_image",
+    });
+  });
+
+  it("normalizes canonical URLs without duplicate slashes", () => {
+    expect(
+      createCanonicalUrl("https://corwinmarsh.com/", "/blog/oil-code"),
+    ).toBe("https://corwinmarsh.com/blog/oil-code");
+  });
+
+  it("finds the origin from root loader data", () => {
+    expect(
+      getOriginFromMatches([
+        { id: "routes/blog", data: {} },
+        { id: "root", data: { origin: "https://corwinmarsh.com" } },
+      ]),
+    ).toBe("https://corwinmarsh.com");
+  });
+
+  it("describes the site with specific positioning", () => {
+    expect(defaultSiteDescription).toContain("software architect");
+    expect(defaultSiteDescription).toContain("developer tooling");
+  });
+});

--- a/app/lib/seo.ts
+++ b/app/lib/seo.ts
@@ -1,0 +1,103 @@
+export const siteName = "Corwin W. Marsh";
+export const siteAuthor = "Corwin W. Marsh";
+export const twitterHandle = "@CorwinMarsh";
+export const defaultSiteDescription =
+  "Corwin Marsh is a software architect in the Greater Seattle Area writing about frontend engineering, developer tooling, and AI-assisted software workflows.";
+export const defaultOgImage = "/profile-2025.jpg";
+
+export type MetaDescriptor =
+  | { title: string }
+  | { name: string; content: string }
+  | { property: string; content: string }
+  | { tagName: "link"; rel: string; href: string };
+
+export interface BuildMetaOptions {
+  origin?: string;
+  pathname?: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  type?: "website" | "article";
+  noIndex?: boolean;
+  publishedTime?: string;
+}
+
+type RouteMatch = {
+  id: string;
+  data?: unknown;
+};
+
+export function getOriginFromMatches(
+  matches: readonly (RouteMatch | undefined)[],
+) {
+  const rootData = matches.find((match) => match?.id === "root")?.data;
+
+  if (
+    rootData &&
+    typeof rootData === "object" &&
+    "origin" in rootData &&
+    typeof rootData.origin === "string"
+  ) {
+    return rootData.origin;
+  }
+
+  return undefined;
+}
+
+function absoluteUrl(origin: string | undefined, value: string) {
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return value;
+  }
+
+  const safeOrigin = origin?.replace(/\/$/, "") ?? "";
+  const safePath = value.startsWith("/") ? value : `/${value}`;
+  return `${safeOrigin}${safePath}`;
+}
+
+export function createCanonicalUrl(origin: string | undefined, pathname = "/") {
+  const safeOrigin = origin?.replace(/\/$/, "") ?? "";
+  const safePath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return `${safeOrigin}${safePath}`;
+}
+
+export function buildMeta({
+  origin,
+  pathname = "/",
+  title = siteName,
+  description = defaultSiteDescription,
+  image = defaultOgImage,
+  type = "website",
+  noIndex = false,
+  publishedTime,
+}: BuildMetaOptions = {}): MetaDescriptor[] {
+  const canonicalUrl = createCanonicalUrl(origin, pathname);
+  const imageUrl = absoluteUrl(origin, image);
+  const meta: MetaDescriptor[] = [
+    { title },
+    { name: "description", content: description },
+    { name: "author", content: siteAuthor },
+    { property: "og:site_name", content: siteName },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:type", content: type },
+    { property: "og:image", content: imageUrl },
+    { property: "og:url", content: canonicalUrl },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:site", content: twitterHandle },
+    { name: "twitter:creator", content: twitterHandle },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+    { name: "twitter:image", content: imageUrl },
+    { tagName: "link", rel: "canonical", href: canonicalUrl },
+  ];
+
+  if (type === "article" && publishedTime) {
+    meta.push({ property: "article:published_time", content: publishedTime });
+  }
+
+  if (noIndex) {
+    meta.push({ name: "robots", content: "noindex, nofollow" });
+  }
+
+  return meta;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-router";
 import styles from "./app.css?url";
 import AppLayout from "./components/layout";
+import { buildMeta } from "./lib/seo";
 
 function safeSerialize(data: unknown) {
   return JSON.stringify(data).replace(/</g, "\\u003c");
@@ -25,61 +26,7 @@ export const links: LinksFunction = () => [
 ];
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
-  {
-    title: `Corwin W. Marsh`,
-  },
-  {
-    name: "description",
-    content: `Corwin Marsh's personal site.`,
-  },
-  {
-    name: "author",
-    content: `Corwin W. Marsh`,
-  },
-  {
-    name: "twitter",
-    content: `@CorwinMarsh`,
-  },
-  {
-    property: "og:title",
-    content: `Corwin W. Marsh`,
-  },
-  {
-    property: "og:description",
-    content: `Corwin Marsh's personal site.`,
-  },
-  {
-    property: "og:type",
-    content: "website",
-  },
-  {
-    property: "og:image",
-    content: `${data?.origin}/profile-2025.jpg`,
-  },
-  {
-    property: "og:url",
-    content: data?.origin,
-  },
-  {
-    name: "twitter:card",
-    content: "summary",
-  },
-  {
-    name: "twitter:creator",
-    content: `@CorwinMarsh`,
-  },
-  {
-    name: "twitter:title",
-    content: `Corwin W. Marsh`,
-  },
-  {
-    name: "twitter:description",
-    content: `Corwin Marsh's personal site.`,
-  },
-  {
-    name: "twitter:image",
-    content: `${data?.origin}/profile-2025.jpg`,
-  },
+  ...buildMeta({ origin: data?.origin }),
 ];
 
 function getEnv() {

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -1,60 +1,22 @@
 import { Link } from "react-router";
+import { getBlogPostSummaries } from "~/content/blog";
+import { buildMeta, getOriginFromMatches } from "~/lib/seo";
 import { type Route } from "./+types/blog._index";
 
-export const meta: Route.MetaFunction = () => [
-  { title: "Writing - Corwin W. Marsh" },
-  {
-    name: "description",
-    content:
+export const meta: Route.MetaFunction = ({ matches }) => [
+  ...buildMeta({
+    origin: getOriginFromMatches(matches),
+    pathname: "/blog",
+    title: "Writing - Corwin W. Marsh",
+    description:
       "Technical writing from Corwin Marsh on software engineering, developer tooling, and AI-assisted workflows.",
-  },
-  { property: "og:title", content: "Writing - Corwin W. Marsh" },
-  {
-    property: "og:description",
-    content:
-      "Technical writing from Corwin Marsh on software engineering, developer tooling, and AI-assisted workflows.",
-  },
-  { property: "og:type", content: "website" },
-  { name: "twitter:card", content: "summary" },
+  }),
 ];
 
-type MdxFrontmatterMeta = { title?: string; name?: string; content?: string };
-
-type BlogMdxModule = {
-  frontmatter: {
-    created?: string;
-    meta: MdxFrontmatterMeta[];
-  };
-};
-
-function postFromModule(fileName: string, mod: BlogMdxModule) {
-  return {
-    slug: fileName.replace(/\.mdx?$/, "").replace(/blog\./, ""),
-    created: mod.frontmatter.created,
-    title: mod.frontmatter.meta.find((meta: MdxFrontmatterMeta) => meta.title)
-      ?.title,
-    description: mod.frontmatter.meta.find(
-      (meta: MdxFrontmatterMeta) => meta.name === "description",
-    )?.content,
-    img: mod.frontmatter.meta.find(
-      (meta: MdxFrontmatterMeta) => meta.name === "og:image",
-    )?.content,
-  };
-}
-
 export async function loader() {
-  const posts = import.meta.glob("./blog.*.mdx", { eager: true });
-  const postEntries = Object.entries(posts);
-  return postEntries
-    .map(([fileName, mod]) => postFromModule(fileName, mod as BlogMdxModule))
-    .sort((a, b) => {
-      if (a.created && b.created) {
-        const dateA = new Date(a.created.replace(/(\d+)(st|nd|rd|th)/, "$1"));
-        const dateB = new Date(b.created.replace(/(\d+)(st|nd|rd|th)/, "$1"));
-        return dateB.getTime() - dateA.getTime();
-      }
-      return 0;
-    });
+  return getBlogPostSummaries(
+    import.meta.glob("./blog.*.mdx", { eager: true }),
+  );
 }
 
 export default function Index({ loaderData }: Route.ComponentProps) {
@@ -89,7 +51,9 @@ export default function Index({ loaderData }: Route.ComponentProps) {
               <div className="relative h-48 overflow-hidden">
                 <img
                   src={post.img}
-                  alt=""
+                  alt={post.title ?? ""}
+                  loading="lazy"
+                  decoding="async"
                   className="absolute inset-0 h-full w-full object-cover transform group-hover:scale-105 transition duration-500"
                   style={{
                     viewTransitionName: `blog-image-${post.slug.replaceAll("./", "")}`,
@@ -108,8 +72,11 @@ export default function Index({ loaderData }: Route.ComponentProps) {
                 )}
                 <div className="mt-auto">
                   {post.created && (
-                    <time className="text-sm text-gray-500 dark:text-gray-400">
-                      {post.created}
+                    <time
+                      dateTime={post.created}
+                      className="text-sm text-gray-500 dark:text-gray-400"
+                    >
+                      {post.displayDate}
                     </time>
                   )}
                 </div>

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -7,9 +7,9 @@ export const meta: Route.MetaFunction = ({ matches }) => [
   ...buildMeta({
     origin: getOriginFromMatches(matches),
     pathname: "/blog",
-    title: "Writing - Corwin W. Marsh",
+    title: "Notes from the workbench - Corwin W. Marsh",
     description:
-      "Technical writing from Corwin Marsh on software engineering, developer tooling, and AI-assisted workflows.",
+      "Things Corwin Marsh is building, breaking, learning, and occasionally overthinking.",
   }),
 ];
 
@@ -23,10 +23,12 @@ export default function Index({ loaderData }: Route.ComponentProps) {
   return (
     <div className="mx-auto py-16">
       <div className="mx-auto mb-16 max-w-2xl text-center">
-        <h1 className="text-4xl font-bold tracking-tight">Writing</h1>
+        <h1 className="text-4xl font-bold tracking-tight">
+          Notes from the workbench
+        </h1>
         <p className="mt-4 text-slate-600 dark:text-slate-400">
-          Notes on software engineering, developer tooling, and the occasional
-          experiment that deserves a longer explanation.
+          Things I'm building, breaking, learning, and occasionally
+          overthinking.
         </p>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-12 gap-y-12">

--- a/app/routes/blog.introduction.mdx
+++ b/app/routes/blog.introduction.mdx
@@ -7,10 +7,23 @@ meta:
     content: https://i.imgflip.com/8b1xna.jpg
 headers:
   Cache-Control: s-max-age=2592000, stale-while-revalidate=86400, stale-if-error=604800
-created: January 1st, 2024
+created: 2024-01-01
 ---
 
-export const meta = frontmatter.meta;
+import { formatDisplayDate } from "~/content/blog";
+import { buildMeta, getOriginFromMatches } from "~/lib/seo";
+
+export const meta = ({ location, matches }) =>
+  buildMeta({
+    origin: getOriginFromMatches(matches),
+    pathname: location.pathname,
+    title: frontmatter.meta[0].title,
+    description: frontmatter.meta.find((item) => item.name === "description")
+      ?.content,
+    image: frontmatter.meta.find((item) => item.name === "og:image")?.content,
+    type: "article",
+    publishedTime: frontmatter.created,
+  });
 export const headers = frontmatter.headers;
 
 <header className="py-12">
@@ -23,12 +36,13 @@ export const headers = frontmatter.headers;
     {frontmatter.meta[0].title}
   </h2>
   <p className="leading-normal text-gray-600 dark:text-gray-300">
-    {frontmatter.created}
+    {formatDisplayDate(frontmatter.created)}
   </p>
 </header>
 
 <img
   src="https://i.imgflip.com/8b1xna.jpg"
+  alt="A meme introducing Corwin Marsh's blog"
   title="made at imgflip.com"
   style={{ viewTransitionName: "blog-image-introduction" }}
 />

--- a/app/routes/blog.oil-code.mdx
+++ b/app/routes/blog.oil-code.mdx
@@ -7,10 +7,23 @@ meta:
     content: https://i.imgflip.com/9wnvrp.jpg
 headers:
   Cache-Control: s-max-age=2592000, stale-while-revalidate=86400, stale-if-error=604800
-created: Jul 28th, 2025
+created: 2025-07-28
 ---
 
-export const meta = frontmatter.meta;
+import { formatDisplayDate } from "~/content/blog";
+import { buildMeta, getOriginFromMatches } from "~/lib/seo";
+
+export const meta = ({ location, matches }) =>
+  buildMeta({
+    origin: getOriginFromMatches(matches),
+    pathname: location.pathname,
+    title: frontmatter.meta[0].title,
+    description: frontmatter.meta.find((item) => item.name === "description")
+      ?.content,
+    image: frontmatter.meta.find((item) => item.name === "og:image")?.content,
+    type: "article",
+    publishedTime: frontmatter.created,
+  });
 export const headers = frontmatter.headers;
 
 <header className="py-12">
@@ -23,7 +36,7 @@ export const headers = frontmatter.headers;
     {frontmatter.meta[0].title}
   </h2>
   <p className="leading-normal text-gray-600 dark:text-gray-300">
-    {frontmatter.created}
+    {formatDisplayDate(frontmatter.created)}
   </p>
 </header>
 

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -11,15 +11,16 @@ import { ExperienceItem } from "~/components/experience-item";
 import { PrintButton } from "~/components/print-button";
 import ResumeLayout from "~/components/resume-layout";
 import { resumeProjects } from "~/content/projects";
+import { buildMeta, getOriginFromMatches } from "~/lib/seo";
 
-export const meta: MetaFunction = () => [
-  {
+export const meta: MetaFunction = ({ matches }) => [
+  ...buildMeta({
+    origin: getOriginFromMatches(matches),
+    pathname: "/resume",
     title: "Resume - Corwin W. Marsh",
-  },
-  {
-    name: "description",
-    content: "Corwin Marsh's professional resume",
-  },
+    description:
+      "Corwin Marsh's professional resume, including software architecture experience, technical skills, and selected developer tooling projects.",
+  }),
 ];
 
 export function headers() {

--- a/app/routes/robots[.]txt.ts
+++ b/app/routes/robots[.]txt.ts
@@ -1,0 +1,14 @@
+import { buildRobotsTxt } from "~/lib/feeds";
+import { type Route } from "./+types/robots[.]txt";
+
+export function loader({ request }: Route.LoaderArgs) {
+  const origin = new URL(request.url).origin;
+
+  return new Response(buildRobotsTxt(origin), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control":
+        "s-max-age=3600, stale-while-revalidate=86400, stale-if-error=604800",
+    },
+  });
+}

--- a/app/routes/rss[.]xml.ts
+++ b/app/routes/rss[.]xml.ts
@@ -1,0 +1,16 @@
+import { buildRssFeed } from "~/lib/feeds";
+import { getBlogPostSummaries } from "~/content/blog";
+import { type Route } from "./+types/rss[.]xml";
+
+export function loader({ request }: Route.LoaderArgs) {
+  const posts = import.meta.glob("./blog.*.mdx", { eager: true });
+  const origin = new URL(request.url).origin;
+
+  return new Response(buildRssFeed(origin, getBlogPostSummaries(posts)), {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control":
+        "s-max-age=3600, stale-while-revalidate=86400, stale-if-error=604800",
+    },
+  });
+}

--- a/app/routes/sitemap[.]xml.ts
+++ b/app/routes/sitemap[.]xml.ts
@@ -1,0 +1,29 @@
+import { getBlogPostSummaries } from "~/content/blog";
+import { buildSitemapXml, type SitemapEntry } from "~/lib/feeds";
+import { type Route } from "./+types/sitemap[.]xml";
+
+export function loader({ request }: Route.LoaderArgs) {
+  const posts = getBlogPostSummaries(
+    import.meta.glob("./blog.*.mdx", { eager: true }),
+  );
+  const origin = new URL(request.url).origin;
+  const entries: SitemapEntry[] = [
+    { path: "/", changefreq: "monthly", priority: "1.0" },
+    { path: "/blog", changefreq: "weekly", priority: "0.8" },
+    { path: "/resume", changefreq: "monthly", priority: "0.6" },
+    ...posts.map((post) => ({
+      path: `/blog/${post.slug}`,
+      lastmod: post.created,
+      changefreq: "monthly" as const,
+      priority: "0.7",
+    })),
+  ];
+
+  return new Response(buildSitemapXml(origin, entries), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control":
+        "s-max-age=3600, stale-while-revalidate=86400, stale-if-error=604800",
+    },
+  });
+}

--- a/app/routes/wishlist.tsx
+++ b/app/routes/wishlist.tsx
@@ -5,6 +5,7 @@ import { motion } from "motion/react";
 import { type MetaFunction } from "react-router";
 import { ProfileLink } from "~/components/profile-link";
 import ProfileSection from "~/components/profile-section";
+import { buildMeta, getOriginFromMatches } from "~/lib/seo";
 
 export function headers() {
   return {
@@ -13,30 +14,14 @@ export function headers() {
   };
 }
 
-export const meta: MetaFunction = () => [
-  {
-    title: `Wishlists`,
-  },
-  {
-    name: "description",
-    content: `Corwin Marsh's family wishlists.`,
-  },
-  {
-    name: "author",
-    content: `Corwin W. Marsh`,
-  },
-  {
-    property: "og:title",
-    content: `Wishlists`,
-  },
-  {
-    property: "og:description",
-    content: `Corwin Marsh's family wishlists.`,
-  },
-  {
-    property: "og:type",
-    content: "website",
-  },
+export const meta: MetaFunction = ({ matches }) => [
+  ...buildMeta({
+    origin: getOriginFromMatches(matches),
+    pathname: "/wishlist",
+    title: "Wishlists - Corwin W. Marsh",
+    description: "Corwin Marsh's family wishlists.",
+    noIndex: true,
+  }),
 ];
 
 export const loader = async () => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "react-router build",
     "typecheck": "react-router typegen && tsc --build --noEmit",
     "lint": "oxlint app",
-    "format": "oxfmt"
+    "format": "oxfmt",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
@@ -51,7 +52,8 @@
     "remark-mdx-frontmatter": "^5.2.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
-    "vite": "^8.0.5"
+    "vite": "^8.0.5",
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       vite:
         specifier: ^8.0.5
         version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@edge-runtime/vm@3.2.0)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -1246,6 +1249,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
@@ -1348,8 +1354,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1479,6 +1491,35 @@ packages:
   '@vercel/static-config@3.2.0':
     resolution: {integrity: sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==}
 
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1517,6 +1558,10 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -1612,6 +1657,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1786,6 +1835,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1851,6 +1903,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -2423,6 +2479,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -2745,6 +2804,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.0.2:
     resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
     engines: {node: '>=14'}
@@ -2771,9 +2833,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -2807,6 +2875,13 @@ packages:
     resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
     engines: {node: '>=10'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.3:
+    resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2814,6 +2889,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3019,11 +3098,57 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -3927,6 +4052,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -4017,9 +4144,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -4153,6 +4287,47 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   abbrev@3.0.1: {}
 
   accepts@1.3.8:
@@ -4184,6 +4359,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -4288,6 +4465,8 @@ snapshots:
   caniuse-lite@1.0.30001782: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -4422,6 +4601,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4546,6 +4727,8 @@ snapshots:
   etag@1.8.1: {}
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.3.0: {}
 
   express@4.22.1:
     dependencies:
@@ -5310,6 +5493,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -5691,6 +5876,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.0.2: {}
 
   smol-toml@1.5.2: {}
@@ -5708,7 +5895,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
@@ -5745,12 +5936,18 @@ snapshots:
     dependencies:
       convert-hrtime: 3.0.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5931,12 +6128,45 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.7(@edge-runtime/vm@3.2.0)(@types/node@25.5.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@types/node': 25.5.2
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- Add shared SEO helpers for canonical, Open Graph, Twitter, and article metadata
- Normalize blog post dates to ISO and centralize blog post summary generation
- Add RSS, sitemap, and robots.txt resource routes while keeping wishlist out of the sitemap and marked noindex
- Add Vitest coverage for SEO/feed/blog helper behavior and run tests in CI
- Improve blog image alt/loading attributes and route metadata

## Verification
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- Smoke-tested /robots.txt, /sitemap.xml, /rss.xml, /blog, /blog/oil-code, and /wishlist with react-router-serve